### PR TITLE
Support dtd and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,6 @@ Ruby implementation of cXML protocol.
 
 Procotol specifications could be found here [http://xml.cxml.org/current/cXMLUsersGuide.pdf](http://xml.cxml.org/current/cXMLUsersGuide.pdf)
 
-To add a DTD and version, add a cxml.rb in config/initializers
-
-```
-CXML.configure do |c|
-  CXML.cxml_version = '1.2.047'
-end
-```
-
 Replace the cxml_version with your CXML standard version of choice.
 
 ## Running Tests

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Ruby implementation of cXML protocol.
 
 Procotol specifications could be found here [http://xml.cxml.org/current/cXMLUsersGuide.pdf](http://xml.cxml.org/current/cXMLUsersGuide.pdf)
 
-Replace the cxml_version with your CXML standard version of choice.
-
 ## Running Tests
 
 Install dependencies:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Ruby implementation of cXML protocol.
 
 Procotol specifications could be found here [http://xml.cxml.org/current/cXMLUsersGuide.pdf](http://xml.cxml.org/current/cXMLUsersGuide.pdf)
 
+To add a DTD and version, add a cxml.rb in config/initializers
+
+```
+CXML.configure do |c|
+  CXML.cxml_version = '1.2.047'
+end
+```
+
+Replace the cxml_version with your CXML standard version of choice.
+
 ## Running Tests
 
 Install dependencies:

--- a/lib/cxml.rb
+++ b/lib/cxml.rb
@@ -37,7 +37,7 @@ module CXML
   # Build the initial XML object which will be used to add the CXML structure into.
   # @return [Nokogiri::XML::Builder] containing basic CXML specification
   def self.builder
-    xml_builder = Nokogiri::XML::Builder.new(:encoding => "UTF-8")
+    xml_builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8')
     add_dtd!(xml_builder)
     xml_builder
   end

--- a/lib/cxml.rb
+++ b/lib/cxml.rb
@@ -29,11 +29,26 @@ module CXML
   autoload :ItemDetail,                   'cxml/item_detail'
   autoload :Money,                        'cxml/money'
 
-  def self.parse(str)
-    CXML::Parser.new.parse(str)
-  end
+  class << self
+    mattr_accessor :cxml_version
 
-  def self.builder
-    Nokogiri::XML::Builder.new(:encoding => "UTF-8")
+    def configure(&block)
+      yield self
+    end
+
+    def parse(str)
+      CXML::Parser.new.parse(str)
+    end
+
+    def builder
+      xml_builder = Nokogiri::XML::Builder.new(:encoding => "UTF-8")
+      return xml_builder unless cxml_version.present?
+      add_dtd!(xml_builder)
+      xml_builder
+    end
+
+    def add_dtd!(xml_builder)
+      xml_builder.doc.create_internal_subset('cXML', nil, "http://xml.cxml.org/schemas/cXML/#{cxml_version}/cXML.dtd")
+    end
   end
 end

--- a/lib/cxml.rb
+++ b/lib/cxml.rb
@@ -3,6 +3,7 @@ require 'cxml/errors'
 require 'time'
 require 'nokogiri'
 
+# Gem module starts by loading all of the classes containing the rest of the gem behaviour.
 module CXML
   autoload :BillTo,                       'cxml/bill_to'
   autoload :Contact,                      'cxml/contact'
@@ -33,12 +34,17 @@ module CXML
     CXML::Parser.new.parse(str)
   end
 
+  # Build the initial XML object which will be used to add the CXML structure into.
+  # @return [Nokogiri::XML::Builder] containing basic CXML specification
   def self.builder
     xml_builder = Nokogiri::XML::Builder.new(:encoding => "UTF-8")
     add_dtd!(xml_builder)
     xml_builder
   end
 
+  # Use Nokogiri's create_internal_subset method to add the DTD at this stage.
+  # This method destructively changes the builder it's run on.
+  # @return [Nokogiri::XML::DTD]
   def self.add_dtd!(xml_builder)
     xml_builder.doc.create_internal_subset('cXML', nil, "http://xml.cxml.org/schemas/cXML/#{CXML::Protocol.version}/cXML.dtd")
   end

--- a/lib/cxml.rb
+++ b/lib/cxml.rb
@@ -29,26 +29,17 @@ module CXML
   autoload :ItemDetail,                   'cxml/item_detail'
   autoload :Money,                        'cxml/money'
 
-  class << self
-    mattr_accessor :cxml_version
+  def self.parse(str)
+    CXML::Parser.new.parse(str)
+  end
 
-    def configure(&block)
-      yield self
-    end
+  def self.builder
+    xml_builder = Nokogiri::XML::Builder.new(:encoding => "UTF-8")
+    add_dtd!(xml_builder)
+    xml_builder
+  end
 
-    def parse(str)
-      CXML::Parser.new.parse(str)
-    end
-
-    def builder
-      xml_builder = Nokogiri::XML::Builder.new(:encoding => "UTF-8")
-      return xml_builder unless cxml_version.present?
-      add_dtd!(xml_builder)
-      xml_builder
-    end
-
-    def add_dtd!(xml_builder)
-      xml_builder.doc.create_internal_subset('cXML', nil, "http://xml.cxml.org/schemas/cXML/#{cxml_version}/cXML.dtd")
-    end
+  def self.add_dtd!(xml_builder)
+    xml_builder.doc.create_internal_subset('cXML', nil, "http://xml.cxml.org/schemas/cXML/#{CXML::Protocol.version}/cXML.dtd")
   end
 end

--- a/lib/cxml/document.rb
+++ b/lib/cxml/document.rb
@@ -12,7 +12,7 @@ module CXML
 
     def initialize(data={})
       if data.kind_of?(Hash) && !data.empty?
-        @version = data['version']
+        @version = data['version'] || CXML::Protocol.version
         @payload_id = data['payloadID']
         @xml_lang = data['xml:lang'] if data['xml:lang']
 
@@ -35,7 +35,6 @@ module CXML
         if data['Message'] && data['Message']['PunchOutOrderMessage']
           @punch_out_order_message = CXML::PunchOutOrderMessage.new(data['Message']['PunchOutOrderMessage'])
         end
-
       end
     end
 

--- a/lib/cxml/version.rb
+++ b/lib/cxml/version.rb
@@ -1,3 +1,3 @@
 module CXML
-  VERSION = '0.1.8'
+  VERSION = '0.1.9'
 end


### PR DESCRIPTION
Send back the DTD as specified in the CXML standard. If no overriding version is sent by the client site, return the hardcoded one which is already defined in the protocol class.