### PR TITLE
NATACC-741 Don't swap creds for POOM

### DIFF
--- a/lib/cxml.rb
+++ b/lib/cxml.rb
@@ -14,6 +14,7 @@ module CXML
   autoload :CredentialMac,                'cxml/credential_mac'
   autoload :From,                         'cxml/from'
   autoload :Sender,                       'cxml/sender'
+  autoload :To,                           'cxml/to'
   autoload :ShipTo,                       'cxml/ship_to'
   autoload :Status,                       'cxml/status'
   autoload :OrderRequest,                 'cxml/order_request'

--- a/lib/cxml/document.rb
+++ b/lib/cxml/document.rb
@@ -71,7 +71,7 @@ module CXML
     def render
       node = CXML.builder
       node.cXML(build_attributes) do |doc|
-        doc.Header { |n| @header.render(n, punch_out_order_message?) } if @header
+        doc.Header { |n| @header.render(n) } if @header
         @request.render(node) if @request
         @response.render(node) if @response
         @punch_out_order_message.render(node) if punch_out_order_message?

--- a/lib/cxml/header.rb
+++ b/lib/cxml/header.rb
@@ -26,7 +26,7 @@ module CXML
       return if !data.is_a?(Hash) || data.empty?
 
       @from       = CXML::From.new(data['From'])
-      @to         = CXML::Credential.new(data['To']['Credential'])
+      @to         = CXML::To.new(data['To'])
       @sender     = CXML::Sender.new(data['Sender'])
     end
 
@@ -42,18 +42,9 @@ module CXML
       !sender.nil?
     end
 
-    # Note: If an original request header is been used for a response, i.e. as part of a PunchOutOrderMessage response
-    #       then swap the to and from nodes
-    def render(node, swap_to_from=false)
-      if to? && from?
-        if swap_to_from
-          node.From   { |n| @to.render(n) }
-          node.To     { |n| @from.render(n) }
-        else
-          node.From   { |n| @from.render(n)  }
-          node.To     { |n| @to.render(n) }
-        end
-      end
+    def render(node)
+      @from.render(node) if from?
+      @to.render(node) if to?
       @sender.render(node) if sender?
       node
     end

--- a/lib/cxml/item_detail.rb
+++ b/lib/cxml/item_detail.rb
@@ -11,6 +11,8 @@ module CXML
     attr_accessor :unit_price
     attr_accessor :unspsc
     attr_accessor :lead_time
+    attr_accessor :manufacturer_name
+    attr_accessor :manufacturer_part_id
 
     def initialize(data={})
       if data.kind_of?(Hash) && !data.empty?
@@ -19,6 +21,8 @@ module CXML
         @unit_of_measure = data['UnitOfMeasure']
         @unspsc = data['ClassificationUnspsc']
         @lead_time = data['LeadTime']
+        @manufacturer_name = data['ManufacturerName']
+        @manufacturer_part_id = data['ManufacturerPartID']
       end
     end
 
@@ -27,6 +31,8 @@ module CXML
         node.UnitPrice{unit_price.render(node)}
         node.Description(description, {'xml:lang' => 'en'})
         node.UnitOfMeasure(unit_of_measure)
+        node.ManufacturerName(manufacturer_name) if manufacturer_name.present?
+        node.ManufacturerPartID(manufacturer_part_id) if manufacturer_part_id.present?
         node.Classification(unspsc, {'domain' => 'UNSPSC'}) unless unspsc.blank?
         node.LeadTime(lead_time) if lead_time.present?
       end

--- a/lib/cxml/item_detail.rb
+++ b/lib/cxml/item_detail.rb
@@ -10,9 +10,9 @@ module CXML
     attr_accessor :unit_of_measure
     attr_accessor :unit_price
     attr_accessor :unspsc
-    attr_accessor :lead_time
-    attr_accessor :manufacturer_name
     attr_accessor :manufacturer_part_id
+    attr_accessor :manufacturer_name
+    attr_accessor :lead_time
 
     def initialize(data={})
       if data.kind_of?(Hash) && !data.empty?
@@ -20,9 +20,9 @@ module CXML
         @description = data['Description']
         @unit_of_measure = data['UnitOfMeasure']
         @unspsc = data['ClassificationUnspsc']
-        @lead_time = data['LeadTime']
-        @manufacturer_name = data['ManufacturerName']
         @manufacturer_part_id = data['ManufacturerPartID']
+        @manufacturer_name = data['ManufacturerName']
+        @lead_time = data['LeadTime']
       end
     end
 
@@ -31,9 +31,9 @@ module CXML
         node.UnitPrice{unit_price.render(node)}
         node.Description(description, {'xml:lang' => 'en'})
         node.UnitOfMeasure(unit_of_measure)
-        node.ManufacturerName(manufacturer_name) if manufacturer_name.present?
-        node.ManufacturerPartID(manufacturer_part_id) if manufacturer_part_id.present?
         node.Classification(unspsc, {'domain' => 'UNSPSC'}) unless unspsc.blank?
+        node.ManufacturerPartID(manufacturer_part_id) if manufacturer_part_id.present?
+        node.ManufacturerName(manufacturer_name) if manufacturer_name.present?
         node.LeadTime(lead_time) if lead_time.present?
       end
     end

--- a/lib/cxml/to.rb
+++ b/lib/cxml/to.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 module CXML
-  # From CXML User Guide: This element identifies the originator of the cXML request.
-  class From
+  # From CXML User Guide: This element identifies the destination of the cXML request.
+  class To
     attr_accessor :credential
 
     # On initialize, we build the Credentials and the UserAgent.
     # This is called when ingesting a CXML object and when building one.
-    # @param data [Hash] The From data for the CXML object that's being handled.
+    # @param data [Hash] The To data for the CXML object that's being handled.
     def initialize(data = {})
       return if !data.is_a?(Hash) || data.empty?
 
@@ -16,9 +16,9 @@ module CXML
 
     # This is only called when building a CXML object, not when ingesting one.
     # @param node [Nokogiri::XML::Builder] The XML object being built in Nokogiri.
-    # @return [Nokogiri::XML::Builder] The XML object, with added From attribute.
+    # @return [Nokogiri::XML::Builder] The XML object, with added To attribute.
     def render(node)
-      node.From do |n|
+      node.To do |n|
         @credential.each{ |c| c.render(n) }
       end
       node

--- a/lib/cxml/version.rb
+++ b/lib/cxml/version.rb
@@ -1,3 +1,3 @@
 module CXML
-  VERSION = '0.2.3'
+  VERSION = '0.2.4'
 end

--- a/lib/cxml/version.rb
+++ b/lib/cxml/version.rb
@@ -1,3 +1,3 @@
 module CXML
-  VERSION = '0.2.4'
+  VERSION = '0.2.5'
 end


### PR DESCRIPTION
We no longer need to swap the creds for POOM because I have implemented a more sophisticated credential system than that in the authenticator. We'll just present the creds we're given instead like for other objects.

I've also added the two new manufacturer fields to ItemDetail as TFL have requested.