### PR TITLE
Natacc 1669 sdi remove supplier setup attribute requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 *.rbc
 *.swp
+.byebug_history
 *.tmproj
 *~
 .DS_Store

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
 --color
---format=nested
+--format=documentation

--- a/cxml.gemspec
+++ b/cxml.gemspec
@@ -9,9 +9,10 @@ Gem::Specification.new do |s|
   s.authors     = ["Dan Sosedoff"]
   s.email       = ["dan.sosedoff@gmail.com"]
 
+  s.add_development_dependency 'byebug'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec',     '~> 2.13'
-  s.add_development_dependency 'simplecov', '~> 0.7'
+  s.add_development_dependency 'rspec',     '~> 3.13'
+  s.add_development_dependency 'simplecov', '~> 0.22'
 
   s.add_dependency 'nokogiri'
   s.add_dependency 'xml-simple'

--- a/lib/cxml/punch_out_setup_request.rb
+++ b/lib/cxml/punch_out_setup_request.rb
@@ -1,21 +1,19 @@
 module CXML
   class PunchOutSetupRequest
-
     attr_accessor :browser_form_post_url
     attr_accessor :supplier_setup_url
     attr_accessor :buyer_cookie
 
     def initialize(data={})
-      if data.kind_of?(Hash) && !data.empty?
-        @browser_form_post_url = data['BrowserFormPost']['URL']
-        @supplier_setup_url = data['SupplierSetup']['URL']
-        @buyer_cookie = data['BuyerCookie']
-      end
+      return unless data.is_a?(Hash) && data.any?
+
+      @browser_form_post_url = data['BrowserFormPost']['URL']
+      @supplier_setup_url    = data['SupplierSetup']['URL'] if data['SupplierSetup']
+      @buyer_cookie          = data['BuyerCookie']
     end
 
     def response_return_url
       browser_form_post_url.blank? ? '' : browser_form_post_url.squish
     end
-
   end
 end

--- a/lib/cxml/request.rb
+++ b/lib/cxml/request.rb
@@ -14,7 +14,8 @@ module CXML
         @id = data['id']
         @deployment_mode = data['deploymentMode']
         @punch_out_setup_request = CXML::PunchOutSetupRequest.new(data['PunchOutSetupRequest'])
-        @order_request = CXML::OrderRequest.new(data['OrderRequest']) if data['OrderRequest'].present?
+        order_request_data = data['OrderRequest']
+        @order_request = CXML::OrderRequest.new(order_request_data) if order_request_data && !order_request_data.empty?
       end
     end
 

--- a/lib/cxml/version.rb
+++ b/lib/cxml/version.rb
@@ -1,3 +1,3 @@
 module CXML
-  VERSION = '0.2.9'
+  VERSION = '0.3.0'
 end

--- a/spec/fixtures/punch_out_setup_request_doc_without_supplier.xml
+++ b/spec/fixtures/punch_out_setup_request_doc_without_supplier.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+ <cXML payloadID="demoSCAWIG@IESAonline" xml:lang="en-UK" timestamp="2007-04-30T15:52:54+00:00">
+ <Header>
+  <From>
+ <Credential domain="DUNS">
+ <Identity>punchout@test.com</Identity>
+ </Credential>
+</From>
+ <To>
+ <Credential domain="DUNS">
+<Identity>punchout@test.com</Identity>
+</Credential>
+</To>
+ <Sender>
+ <Credential domain="IESAnetworkUserID"> <Identity>88888888</Identity> <SharedSecret>{shared secret in here}</SharedSecret>  </Credential> <UserAgent>IESAonlinevers1</UserAgent>
+</Sender>
+</Header>
+ <Request deploymentMode="production">
+ <PunchOutSetupRequest operation="create"> <BuyerCookie>demoSCAWIGP</BuyerCookie>
+ <BrowserFormPost>
+  <URL>
+    http://return_to_supplier_url.com
+  </URL>
+ </BrowserFormPost>
+</PunchOutSetupRequest>
+</Request>
+</cXML>

--- a/spec/punch_out_setup_request_spec.rb
+++ b/spec/punch_out_setup_request_spec.rb
@@ -2,22 +2,34 @@ require 'spec_helper'
 
 describe CXML::PunchOutSetupRequest do
 
-  it { should respond_to :browser_form_post_url }
-  it { should respond_to :supplier_setup_url }
-
-
-  let(:parser) { CXML::Parser.new }
-  let(:data) { parser.parse(fixture('punch_out_setup_request_doc.xml')) }
-  let(:doc) { CXML::Document.new(data) }
-  let(:request) { doc.request }
-  let(:punch_out_setup_request) { request.punch_out_setup_request }
-
+  it { is_expected.to respond_to(:browser_form_post_url) }
+  it { is_expected.to respond_to(:supplier_setup_url) }
 
   describe '#initialize' do
-    it "sets the mandatory attributes" do
-      punch_out_setup_request.browser_form_post_url.should_not be_nil
-      punch_out_setup_request.supplier_setup_url.should_not be_nil
+    context "when the request data comes with a SupplierSetup block" do
+      let(:parser)  { CXML::Parser.new }
+      let(:data)    { parser.parse(fixture('punch_out_setup_request_doc.xml')) }
+      let(:doc)     { CXML::Document.new(data) }
+      let(:request) { doc.request }
+      let(:punch_out_setup_request) { request.punch_out_setup_request }
+
+      it "sets the mandatory attributes including the SupplierSetup" do
+        expect(punch_out_setup_request.browser_form_post_url).not_to be_nil
+        expect(punch_out_setup_request.supplier_setup_url).not_to be_nil
+      end
+    end
+
+    context "when the request data comes without a SupplierSetup block" do
+      let(:parser)  { CXML::Parser.new }
+      let(:data)    { parser.parse(fixture('punch_out_setup_request_doc_without_supplier.xml')) }
+      let(:doc)     { CXML::Document.new(data) }
+      let(:request) { doc.request }
+      let(:punch_out_setup_request) { request.punch_out_setup_request }
+
+      it "sets the mandatory attributes without the SupplierSetup" do
+        expect(punch_out_setup_request.browser_form_post_url).not_to be_nil
+        expect(punch_out_setup_request.supplier_setup_url).to be_nil
+      end
     end
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,8 @@
 $:.unshift File.expand_path("../..", __FILE__)
 
+require 'byebug'
 require 'cxml'
-require 'ruby-debug'
+require 'simplecov'
 
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f}
 


### PR DESCRIPTION
In this change, we make the SupplierSetup block optional so that Natacc Authenticator is able to accept requests without it. 

Also in this change:
- Upgrade of `rspec` gem as a dev dependency to version 3.13
- Upgrade of `simplecov` gem as a dev dependency to version 0.22
- Switching from `ruby-debug` to `byebug`
- Update of specs for the `PunchOutSetupRequest` class
- Updade of rspec config files
- Remove Rails-dependent `.present?` check and use plain Ruby truthiness

**Background**
Currently, the PunchOutSetupRequest doesn’t work if you remove the <SupplierSetup> element. However, this element isn’t actually necessary for us and it’s deprecated in the cXML standard so we are going to need to be able to accept requests without it. The error occurs on the authenticator and it can easily be replicated by removing the <SupplierSetup> block from any cXML login request in Postman. This will likely involve a change to the cXML gem.

